### PR TITLE
remove the hello route

### DIFF
--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,5 +1,0 @@
-export const dynamic = 'force-dynamic'; // static by default, unless reading the request
- 
-export function GET(request: Request) {
-  return new Response(`Hello from ${process.env.VERCEL_REGION}`);
-}

--- a/app/api/irys.ts
+++ b/app/api/irys.ts
@@ -2,8 +2,8 @@ import Irys from '@irys/sdk';
 import { DEVNET_PROVIDER_URL } from '../constants';
 
 export async function getIrys() {
-	const network = process.env.NEXT_PUBLIC_ENVIRONMENT === "production" ? "mainnet" : "devnet";
-	const providerUrl = process.env.NEXT_PUBLIC_ENVIRONMENT === "production" ? "" : DEVNET_PROVIDER_URL;
+	const network = process.env.NEXT_PUBLIC_IRYS_ENVIRONMENT === "production" ? "mainnet" : "devnet";
+	const providerUrl = process.env.NEXT_PUBLIC_IRYS_ENVIRONMENT === "production" ? "" : DEVNET_PROVIDER_URL;
 	const token = "matic"; //token usado pra pagar o nó do arweave
 	const privateKey = process.env.PRIVATE_KEY;
  


### PR DESCRIPTION
Also, separating Irys (arweave) from the rest of the enviroment info, in order to create the "preview" enviroment, with Irys pointing to production and Lens to testnet.